### PR TITLE
WIP: Observer

### DIFF
--- a/extension/observer/go.mod
+++ b/extension/observer/go.mod
@@ -1,0 +1,3 @@
+module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
+
+go 1.14

--- a/extension/observer/k8s/Makefile
+++ b/extension/observer/k8s/Makefile
@@ -1,0 +1,1 @@
+include ../../../Makefile.Common

--- a/extension/observer/k8s/config.go
+++ b/extension/observer/k8s/config.go
@@ -1,0 +1,35 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+// Config defines configuration for k8s attributes processor.
+type Config struct {
+	configmodels.ExtensionSettings `mapstructure:",squash"`
+
+	// For example, node name can be passed to each agent with the downward API as follows
+	//
+	// env:
+	//   - name: K8S_NODE_NAME
+	//     valueFrom:
+	//       fieldRef:
+	//         fieldPath: spec.nodeName
+	//
+	// Then set this value to ${K8S_NODE_NAME}
+	Node string `mapstructure:"node"`
+}

--- a/extension/observer/k8s/doc.go
+++ b/extension/observer/k8s/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package k8s implements a k8s observer extension for monitoring pods.
+package k8s

--- a/extension/observer/k8s/extension.go
+++ b/extension/observer/k8s/extension.go
@@ -1,0 +1,54 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/uber-go/atomic"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+type k8sObserver struct {
+	logger   *zap.Logger
+	informer cache.SharedInformer
+	running  atomic.Bool
+	stop     chan struct{}
+}
+
+func (k *k8sObserver) Start(host component.Host) error {
+	go k.informer.Run(k.stop)
+	return nil
+}
+
+func (k *k8sObserver) Shutdown() error {
+	close(k.stop)
+	return nil
+}
+
+var _ (component.ServiceExtension) = (*k8sObserver)(nil)
+
+func (k *k8sObserver) ListAndWatch(notify observer.ObserverNotify) {
+	k.informer.AddEventHandler(&responder{notify: notify})
+}
+
+// New creates a new k8s observer extension.
+func New(logger *zap.Logger, config *Config, listWatch cache.ListerWatcher) (component.ServiceExtension, error) {
+	informer := cache.NewSharedInformer(listWatch, &v1.Pod{}, 0)
+	return &k8sObserver{logger: logger, informer: informer, stop: make(chan struct{})}, nil
+}

--- a/extension/observer/k8s/extension_test.go
+++ b/extension/observer/k8s/extension_test.go
@@ -1,0 +1,115 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	framework "k8s.io/client-go/tools/cache/testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+// NewPod is a helper function for creating Pods for testing.
+func NewPod(name, host string) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Spec: v1.PodSpec{
+			NodeName: host,
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	return pod
+}
+
+func TestNewExtension(t *testing.T) {
+	listWatch := framework.NewFakeControllerSource()
+	factory := &Factory{}
+	ext, err := New(zap.NewNop(), factory.CreateDefaultConfig().(*Config), listWatch)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}
+
+type endpointSink struct {
+	sync.Mutex
+	added   []observer.Endpoint
+	removed []observer.Endpoint
+	changed []observer.Endpoint
+}
+
+func (e *endpointSink) OnAdd(added []observer.Endpoint) {
+	e.Lock()
+	defer e.Unlock()
+	e.added = append(e.added, added...)
+}
+
+func (e *endpointSink) OnRemove(removed []observer.Endpoint) {
+	e.Lock()
+	defer e.Unlock()
+	e.removed = append(e.removed, removed...)
+}
+
+func (e *endpointSink) OnChange(changed []observer.Endpoint) {
+	e.Lock()
+	defer e.Unlock()
+	e.changed = append(e.removed, changed...)
+}
+
+var _ observer.ObserverNotify = (*endpointSink)(nil)
+
+func TestExtensionObserve(t *testing.T) {
+	listWatch := framework.NewFakeControllerSource()
+	factory := &Factory{}
+	ext, err := New(zap.NewNop(), factory.CreateDefaultConfig().(*Config), listWatch)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+	obs := ext.(*k8sObserver)
+
+	listWatch.Add(NewPod("pod1", "localhost"))
+
+	require.NoError(t, ext.Start(component.NewMockHost()))
+
+	sink := &endpointSink{}
+	obs.ListAndWatch(sink)
+
+	assert.Eventually(t, func() bool {
+		sink.Lock()
+		defer sink.Unlock()
+		return len(sink.added) == 1
+	}, 1*time.Second, 100*time.Millisecond)
+
+	assert.Equal(t, observer.NewPortEndpoint("pod1", "localhost", 80, nil), sink.added[0])
+
+	defer require.NoError(t, ext.Shutdown())
+}

--- a/extension/observer/k8s/factory.go
+++ b/extension/observer/k8s/factory.go
@@ -1,0 +1,90 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "health_check"
+)
+
+// Factory is the factory for the extension.
+type Factory struct {
+	createK8sConfig func() (*rest.Config, error)
+}
+
+var _ (component.Factory) = (*Factory)(nil)
+
+// Type gets the type of the config created by this factory.
+func (f *Factory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for the extension.
+func (f *Factory) CreateDefaultConfig() configmodels.Extension {
+	return &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+// CreateExtension creates the extension based on this config.
+func (f *Factory) CreateExtension(
+	logger *zap.Logger,
+	cfg configmodels.Extension,
+) (component.ServiceExtension, error) {
+	config := cfg.(*Config)
+
+	restConfig, err := f.createK8sConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed creating Kubernetes in-cluster REST config: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	listWatch := cache.NewListWatchFromClient(
+		clientset.CoreV1().RESTClient(), "pods", v1.NamespaceAll,
+		fields.OneTermEqualSelector("spec.nodeName", config.Node))
+
+	return New(logger, config, listWatch)
+}
+
+// NewFactory should be called to create a factory with default values.
+func NewFactory() *Factory {
+	return &Factory{createK8sConfig: func() (*rest.Config, error) {
+		restConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed creating Kubernetes in-cluster REST config: %v", err)
+		}
+		return restConfig, nil
+	}}
+}

--- a/extension/observer/k8s/factory_test.go
+++ b/extension/observer/k8s/factory_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
+)
+
+func TestFactory_Type(t *testing.T) {
+	factory := Factory{}
+	require.Equal(t, typeStr, factory.Type())
+}
+
+var nilConfig = func() (*rest.Config, error) {
+	return &rest.Config{}, nil
+}
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	factory := Factory{createK8sConfig: nilConfig}
+	cfg := factory.CreateDefaultConfig()
+	assert.Equal(t, &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			NameVal: typeStr,
+			TypeVal: typeStr,
+		},
+	},
+		cfg)
+
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+	ext, err := factory.CreateExtension(zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}
+
+func TestFactory_CreateExtension(t *testing.T) {
+	factory := Factory{createK8sConfig: nilConfig}
+	cfg := factory.CreateDefaultConfig().(*Config)
+
+	ext, err := factory.CreateExtension(zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}

--- a/extension/observer/k8s/go.mod
+++ b/extension/observer/k8s/go.mod
@@ -1,0 +1,20 @@
+module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8s
+
+go 1.14
+
+require (
+	github.com/open-telemetry/opentelemetry-collector v0.2.6
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.4.0
+	github.com/uber-go/atomic v1.4.0
+	go.uber.org/zap v1.13.0
+	k8s.io/api v0.0.0-20190813020757-36bff7324fb7
+	k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010
+	k8s.io/client-go v12.0.0+incompatible
+)
+
+replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+
+replace github.com/open-telemetry/opentelemetry-collector => ../../../../opentelemetry-collector
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer => ../

--- a/extension/observer/k8s/go.sum
+++ b/extension/observer/k8s/go.sum
@@ -485,6 +485,7 @@ github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0 h1:HVfrLniijszjS1
 github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0/go.mod h1:qOQCunEYvmd/TLamH+7LlVccLvUH5kZNhbCgTHoBbp4=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
+github.com/google/addlicense v0.0.0-20190510175307-22550fa7c1b0/go.mod h1:QtPG26W17m+OIQgE6gQ24gC1M6pUaMBAbFrTIDtwG/E=
 github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2 h1:N/H6+jLLYNoskSbyRaph9ttbcaGEw4AWpAZw+1VqIGs=
 github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -495,6 +496,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -629,6 +631,7 @@ github.com/jackc/pgx/v4 v4.4.1/go.mod h1:6iSW+JznC0YT+SgBn7rNxoEBsBgSmnC5FwyCekO
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jaegertracing/jaeger v1.14.0/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jaegertracing/jaeger v1.17.0 h1:SekUYENjk7gp38SJWM7kKuJjZ1EK7dNqE9UjKaCNJD8=
 github.com/jaegertracing/jaeger v1.17.0/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -649,6 +652,7 @@ github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBv
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -657,8 +661,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
-github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.7/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.8/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
@@ -807,10 +809,11 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200320161127-c82c64751e92 h1:ewBkMOziS4w1/pgq1JchMFrk1nw2JFt6Nge03Vn0Mmk=
-github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200320161127-c82c64751e92/go.mod h1:kpj/K5Bo/k97DouieBzd+3AhOJ2RRXSqbSkEA4qwUvg=
-github.com/open-telemetry/opentelemetry-collector v0.3.0 h1:/i106g9t6xNQ4hOAuczEwW10UX+S8ZnkdWDGawo9fyg=
-github.com/open-telemetry/opentelemetry-collector v0.3.0/go.mod h1:c5EgyLBK6FoGCaJpOEQ0j+sHqmfuoRzOm29tdVA/wDg=
+github.com/open-telemetry/opentelemetry-collector v0.2.6/go.mod h1:V1KYdNcKU2881dKDsVrFDq33isfaOcG+k7U2zynMgrk=
+github.com/open-telemetry/opentelemetry-collector-contrib v0.2.7 h1:+2GDVfZ3I6eTr3etXawN6BdYno5RCogDJ1rlH1AxG00=
+github.com/open-telemetry/opentelemetry-collector-contrib v0.2.8 h1:HQLW0k/GyoFgXmrISg2Xv20EoilDKDHmIWK2dKRceKA=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0-20200306174208-b1756046263c/go.mod h1:uhCiQVjrdfXJi85z7vjs59DGENUcwlmxQvqMWWwPpnA=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200316171511-e76584d22418 h1:R4Mjk1d++Hke9e4W33O6CMUS85hALRP5wKjhaeCYuSk=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200316171511-e76584d22418/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.3.0 h1:+ASAtcayvoELyCF40+rdCMlBOhZIn5TPDez85zSYc30=
@@ -1131,6 +1134,7 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoeb
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200320181102-891825fb96df h1:lDWgvUvNnaTnNBc/dwOty86cFeKoKWbwy2wQj0gIxbU=
 golang.org/x/crypto v0.0.0-20200320181102-891825fb96df/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1200,7 +1204,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1370,7 +1373,6 @@ google.golang.org/genproto v0.0.0-20190708153700-3bdd9d9f5532/go.mod h1:z3L6/3dT
 google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 h1:iKtrH9Y8mcbADOP0YFaEMth7OfuHY9xHOwNj4znpM1A=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
@@ -1433,8 +1435,8 @@ k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010 h1:pyoq062NftC1y/OcnbSvgolyZDJ8y4fmUPWMkdA6gfU=
 k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010/go.mod h1:Waf/xTS2FGRrgXCkO5FP3XxTOWh0qLf2QhL1qFZZ/R8=
+k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
-k8s.io/client-go v12.0.0+incompatible h1:YlJxncpeVUC98/WMZKC3JZGk/OXQWCZjAB4Xr3B17RY=
 k8s.io/client-go v12.0.0+incompatible/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/extension/observer/k8s/responder.go
+++ b/extension/observer/k8s/responder.go
@@ -1,0 +1,73 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+// TODO: test object separately
+type responder struct {
+	notify observer.ObserverNotify
+}
+
+func (r *responder) OnAdd(obj interface{}) {
+	pod := obj.(*v1.Pod)
+	r.notify.OnAdd(convertPodToEndpoints(pod))
+}
+
+func convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
+	// TODO
+	return []observer.Endpoint{observer.NewPortEndpoint("localhost", "localhost", 80, nil)}
+}
+
+func (r *responder) OnUpdate(oldObj, newObj interface{}) {
+	oldPod := oldObj.(*v1.Pod)
+	newPod := newObj.(*v1.Pod)
+
+	oldEndpoints := convertPodToEndpoints(oldPod)
+	newEndpoints := convertPodToEndpoints(newPod)
+	_, _ = oldEndpoints, newEndpoints
+
+	// Do diff based on id.
+	//_ = oldEndpoints
+	//_ = newEndpoints
+	// OnDelete endpoints that are no longer present in newEndpoints.
+	// OnAdd endpoints that are only in newEndpoints.
+	// OnChange endpoints (by id) that differ between the old and new.
+
+	// TODO: can changes be missed where a pod is deleted but we don't
+	// send remove notifications for some of its endpoints? If not provable
+	// then maybe keep track of pod -> endpoint association to be sure
+	// they are all cleaned up.
+}
+
+func (r *responder) OnDelete(obj interface{}) {
+	var pod *v1.Pod
+	switch o := obj.(type) {
+	case *cache.DeletedFinalStateUnknown:
+		// Assuming we never saw the pod state where new endpoints would have been created
+		// to begin with it seems that we can't leak endpoints here.
+		pod = o.Obj.(*v1.Pod)
+	case *v1.Pod:
+		pod = o
+	default:
+		return
+	}
+	r.notify.OnRemove(convertPodToEndpoints(pod))
+}

--- a/extension/observer/observer.go
+++ b/extension/observer/observer.go
@@ -1,0 +1,91 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"fmt"
+)
+
+// Protocol defines network protocol for container ports.
+type Protocol string
+
+const (
+	// ProtocolTCP is the TCP protocol.
+	ProtocolTCP Protocol = "TCP"
+	// ProtocolUDP is the UDP protocol.
+	ProtocolUDP Protocol = "UDP"
+)
+
+type Endpoint interface {
+	ID() string
+	String() string
+}
+
+type endpointBase struct {
+	id     string
+	Target string
+	Labels map[string]string
+}
+
+func (e *endpointBase) ID() string {
+	return e.id
+}
+
+type HostEndpoint struct {
+	endpointBase
+}
+
+func (h *HostEndpoint) String() string {
+	return fmt.Sprintf("HostEndpoint{id: %v, Target: %v, Labels: %v}", h.ID(), h.Target, h.Labels)
+}
+
+func NewHostEndpoint(id string, target string, labels map[string]string) *HostEndpoint {
+	return &HostEndpoint{endpointBase{
+		id:     id,
+		Target: target,
+		Labels: labels,
+	}}
+}
+
+var _ Endpoint = (*HostEndpoint)(nil)
+
+type PortEndpoint struct {
+	endpointBase
+	Port int32
+}
+
+func (p *PortEndpoint) String() string {
+	return fmt.Sprintf("PortEndpoint{ID: %v, Target: %v, Port: %d, Labels: %v}", p.ID(), p.Target, p.Port, p.Labels)
+}
+
+func NewPortEndpoint(id string, target string, port int32, labels map[string]string) *PortEndpoint {
+	return &PortEndpoint{endpointBase: endpointBase{
+		id:     id,
+		Target: target,
+		Labels: labels,
+	}, Port: port}
+}
+
+var _ Endpoint = (*PortEndpoint)(nil)
+
+type Observer interface {
+	ListAndWatch(notify ObserverNotify)
+}
+
+type ObserverNotify interface {
+	OnAdd([]Endpoint)
+	OnRemove([]Endpoint)
+	OnChange([]Endpoint)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2
+	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 // indirect
 	github.com/open-telemetry/opentelemetry-collector v0.2.10
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -730,6 +730,7 @@ github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62F
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46Ok=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -746,6 +747,8 @@ github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=
+github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6/go.mod h1:CEusGbCRDFcHX9EgEhPsgJX33kpp9CfSFRBAoSGOems=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.7/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.8/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
@@ -919,6 +922,7 @@ github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/open-telemetry/opentelemetry-collector v0.2.10 h1:8ViMIZq6R8/PvEyKD+C4y2oHIuxLVuMHnJyGK/EAVaE=
 github.com/open-telemetry/opentelemetry-collector v0.2.10/go.mod h1:c5EgyLBK6FoGCaJpOEQ0j+sHqmfuoRzOm29tdVA/wDg=
+github.com/open-telemetry/opentelemetry-collector v0.3.0 h1:/i106g9t6xNQ4hOAuczEwW10UX+S8ZnkdWDGawo9fyg=
 github.com/open-telemetry/opentelemetry-proto v0.3.0 h1:+ASAtcayvoELyCF40+rdCMlBOhZIn5TPDez85zSYc30=
 github.com/open-telemetry/opentelemetry-proto v0.3.0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1302,6 +1306,7 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoeb
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200320181102-891825fb96df h1:lDWgvUvNnaTnNBc/dwOty86cFeKoKWbwy2wQj0gIxbU=
 golang.org/x/crypto v0.0.0-20200320181102-891825fb96df/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -52,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 	r1 := cfg.Receivers["receiver_creator/1"].(*Config)
 
 	assert.NotNil(t, r1)
-	assert.Len(t, r1.subreceiverConfigs, 1)
+	assert.Len(t, r1.subreceiverConfigs, 2)
 	assert.Contains(t, r1.subreceiverConfigs, "examplereceiver/1")
 	assert.Equal(t, "test rule", r1.subreceiverConfigs["examplereceiver/1"].Rule)
 	assert.Equal(t, map[string]interface{}{

--- a/receiver/receivercreator/e2e_test.go
+++ b/receiver/receivercreator/e2e_test.go
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+// Create some pods
+// Load and start observer extension, dynamic receiver
+// Check expected receivers created
+// Create some more pods
+// Check additional receivers created
+// Check metrics received

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -1,10 +1,12 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receiver_creator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
+	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
 	github.com/open-telemetry/opentelemetry-collector v0.3.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.0.0
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.13.0
@@ -12,3 +14,5 @@ require (
 
 // Same version as from go.mod. Required to make go list -m work.
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer => ../../extension/observer

--- a/receiver/receivercreator/responder.go
+++ b/receiver/receivercreator/responder.go
@@ -1,0 +1,104 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+import (
+	"fmt"
+
+	"github.com/jwangsadinata/go-multimap/slicemultimap"
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+type responder struct {
+	runner             receiverRunner
+	logger             *zap.Logger
+	subreceiverConfigs map[string]*subreceiverConfig
+	started            *slicemultimap.MultiMap
+}
+
+var _ observer.ObserverNotify = (*responder)(nil)
+
+// configFromEndpoint returns the configuration map for a receiver based on
+// the provided endpoint.
+func configFromEndpoint(endpoint observer.Endpoint) map[string]interface{} {
+	var receiverEndpoint string
+	switch endpoint := endpoint.(type) {
+	case *observer.HostEndpoint:
+		receiverEndpoint = endpoint.Target
+	case *observer.PortEndpoint:
+		receiverEndpoint = fmt.Sprintf("%s:%d", endpoint.Target, endpoint.Port)
+	}
+
+	return map[string]interface{}{
+		"endpoint": receiverEndpoint,
+	}
+}
+
+// OnAdd is called when a new endpoint appears.
+func (r *responder) OnAdd(endpoints []observer.Endpoint) {
+	for _, e := range endpoints {
+		if r.started.ContainsKey(e.ID()) {
+			r.logger.DPanic("endpoint unexpectedly already present", zap.Stringer("endpoint", e))
+			continue
+		}
+
+		for receiverName, cfg := range r.subreceiverConfigs {
+			matches, err := ruleMatches(e, cfg.Rule)
+			if err != nil {
+				r.logger.Error("failed to apply rule to endpoint", zap.Stringer("endpoint", e), zap.Error(err))
+				continue
+			}
+
+			if !matches {
+				continue
+			}
+
+			envCfg := configFromEndpoint(e)
+			rcvr, err := r.runner.StartReceiver(cfg, envCfg)
+			if err != nil {
+				// TODO: need to figure out how not to log sensitive things (credentials, secrets, etc.)
+				r.logger.Error("failed to run receiver", zap.Stringer("endpoint", e),
+					zap.Error(err), zap.Reflect("cfg", cfg.config), zap.Reflect("envCfg", envCfg))
+				continue
+			}
+
+			r.logger.Info("started receiver", zap.String("name", receiverName), zap.Stringer("endpoint", e))
+			r.started.Put(e.ID(), rcvr)
+		}
+	}
+}
+
+// OnRemove is called when endpoints are gone.
+func (r *responder) OnRemove(endpoints []observer.Endpoint) {
+	for _, e := range endpoints {
+		rcvrs, _ := r.started.Get(e.ID())
+		for _, rcvr := range rcvrs {
+			if err := r.runner.StopReceiver(rcvr.(component.Receiver)); err != nil {
+				r.logger.Error("failed stopping receiver", zap.Any("endpoint", e))
+			}
+		}
+		r.started.RemoveAll(e.ID())
+	}
+}
+
+// OnChange is called when an endpoint is still present but has been modified.
+func (r *responder) OnChange(endpoints []observer.Endpoint) {
+	// TODO: Make this only restart receivers if something relevant has actually changed. (ie the configuration)
+	r.OnRemove(endpoints)
+	r.OnAdd(endpoints)
+}

--- a/receiver/receivercreator/responder_test.go
+++ b/receiver/receivercreator/responder_test.go
@@ -1,0 +1,147 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+type mockLoader struct {
+	mock.Mock
+}
+
+type mockReceiver struct {
+}
+
+func (m *mockReceiver) Start(host component.Host) error {
+	return nil
+}
+
+func (m *mockReceiver) Shutdown() error {
+	return nil
+}
+
+func (m *mockLoader) StartReceiver(cfg *subreceiverConfig, subConfigFromEnv map[string]interface{}) (component.Receiver, error) {
+	args := m.Called(cfg, subConfigFromEnv)
+	return args.Get(0).(component.Receiver), args.Error(1)
+}
+
+func (m *mockLoader) StopReceiver(rcvr component.Receiver) error {
+	args := m.Called(rcvr)
+	return args.Error(0)
+}
+
+func (m *mockLoader) Shutdown() error {
+	return nil
+}
+
+func Test_configFromEndpoint(t *testing.T) {
+	type args struct {
+		endpoint observer.Endpoint
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{"from pod endpoint", args{observer.NewPortEndpoint("pod1", "1.2.3.4", 80, nil)}, map[string]interface{}{
+			"endpoint": "1.2.3.4:80",
+		}},
+		{"from host endpoint", args{observer.NewHostEndpoint("pod1", "1.2.3.4", nil)}, map[string]interface{}{
+			"endpoint": "1.2.3.4",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := configFromEndpoint(tt.args.endpoint); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("configFromEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnAdd(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	loader := &mockLoader{}
+	rcvr := &mockReceiver{}
+	loader.On("StartReceiver", rc.cfg.subreceiverConfigs["examplereceiver/2"], map[string]interface{}{
+		"endpoint": "1.2.3.4",
+	}).Return(rcvr, nil)
+
+	responder := rc.newResponder()
+	responder.runner = loader
+	endpoint := observer.NewHostEndpoint("host1", "1.2.3.4", nil)
+	responder.OnAdd([]observer.Endpoint{endpoint})
+
+	loader.AssertExpectations(t)
+
+	assert.Equal(t, 1, responder.started.Size())
+	assert.True(t, responder.started.Contains(endpoint.ID(), rcvr))
+}
+
+func TestOnRemove(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	loader := &mockLoader{}
+	rcvr := &mockReceiver{}
+	loader.On("StartReceiver", rc.cfg.subreceiverConfigs["examplereceiver/2"], map[string]interface{}{
+		"endpoint": "1.2.3.4",
+	}).Return(rcvr, nil)
+	loader.On("StopReceiver", rcvr).Return(nil)
+
+	responder := rc.newResponder()
+	responder.runner = loader
+	endpoint := observer.NewHostEndpoint("host1", "1.2.3.4", nil)
+
+	responder.OnAdd([]observer.Endpoint{endpoint})
+	require.Equal(t, 1, responder.started.Size())
+
+	responder.OnRemove([]observer.Endpoint{endpoint})
+
+	loader.AssertExpectations(t)
+	assert.Equal(t, 0, responder.started.Size())
+}
+
+func TestOnChange(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	loader := &mockLoader{}
+	rcvr := &mockReceiver{}
+	loader.On("StartReceiver", rc.cfg.subreceiverConfigs["examplereceiver/2"], map[string]interface{}{
+		"endpoint": "1.2.3.4",
+	}).Return(rcvr, nil)
+	loader.On("StopReceiver", rcvr).Return(nil)
+	loader.On("StartReceiver", rc.cfg.subreceiverConfigs["examplereceiver/2"], map[string]interface{}{
+		"endpoint": "1.2.3.4",
+	}).Return(rcvr, nil)
+
+	responder := rc.newResponder()
+	responder.runner = loader
+	endpoint := observer.NewHostEndpoint("host1", "1.2.3.4", nil)
+
+	responder.OnAdd([]observer.Endpoint{endpoint})
+	require.Equal(t, 1, responder.started.Size())
+
+	responder.OnChange([]observer.Endpoint{endpoint})
+
+	loader.AssertExpectations(t)
+	assert.Equal(t, 1, responder.started.Size())
+}

--- a/receiver/receivercreator/rules.go
+++ b/receiver/receivercreator/rules.go
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+
+func ruleMatches(e observer.Endpoint, rule string) (bool, error) {
+	// TODO
+	return rule == "enabled", nil
+}

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -1,0 +1,141 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/oterr"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+type receiverRunner interface {
+	StartReceiver(cfg *subreceiverConfig, subConfigFromEnv map[string]interface{}) (component.Receiver, error)
+	StopReceiver(rcvr component.Receiver) error
+	Shutdown() error
+}
+
+// runner manages loading and running receivers that have been started at runtime.
+type runner struct {
+	sync.Mutex
+	logger             *zap.Logger
+	host               component.Host
+	consumer           consumer.MetricsConsumerOld
+	parentReceiverName string
+	receivers          map[component.Receiver]struct{}
+}
+
+var _ receiverRunner = (*runner)(nil)
+
+// Shutdown all started receivers.
+func (lo *runner) Shutdown() error {
+	lo.Lock()
+	defer lo.Unlock()
+
+	var errs []error
+
+	for recvr := range lo.receivers {
+		if err := recvr.Shutdown(); err != nil {
+			// TODO: Should keep track of which receiver the error is associated with
+			// but require some restructuring.
+			errs = append(errs, err)
+		}
+	}
+
+	lo.receivers = nil
+
+	if len(errs) > 0 {
+		// Or maybe just return a general error and log the failed shutdowns?
+		return fmt.Errorf("shutdown on %d receivers failed: %v", len(errs), oterr.CombineErrors(errs))
+	}
+
+	return nil
+}
+
+// loadRuntimeReceiverConfig loads the given staticSubConfig merged with config values
+// that may have been discovered at runtime.
+func (lo *runner) loadRuntimeReceiverConfig(
+	staticSubConfig *subreceiverConfig,
+	subConfigFromEnv map[string]interface{}) (configmodels.Receiver, error) {
+	// Load config under <receiver>/<id> since loadReceiver and CustomUnmarshaler expects this structure.
+	viperConfig := viper.New()
+	viperConfig.Set(staticSubConfig.fullName, map[string]interface{}{})
+	subreceiverConfig := viperConfig.Sub(staticSubConfig.fullName)
+
+	// Merge in the config values specified in the config file.
+	if err := subreceiverConfig.MergeConfigMap(staticSubConfig.config); err != nil {
+		return nil, fmt.Errorf("failed to merge subreceiver config from config file: %v", err)
+	}
+
+	// Merge in subConfigFromEnv containing values discovered at runtime.
+	if err := subreceiverConfig.MergeConfigMap(subConfigFromEnv); err != nil {
+		return nil, fmt.Errorf("failed to merge subreceiver config from discovered runtime values: %v", err)
+	}
+
+	receiverConfig, err := config.LoadReceiver(staticSubConfig.fullName, viperConfig, factories)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load subreceiver config: %v", err)
+	}
+	// Sets dynamically created receiver to something like receiver_creator/1/redis{endpoint="localhost:6380"}.
+	// TODO: Need to make sure this is unique (just endpoint is probably not totally sufficient).
+	receiverConfig.SetName(fmt.Sprintf("%s/%s{endpoint=%q}", lo.parentReceiverName, staticSubConfig.fullName, subreceiverConfig.GetString("endpoint")))
+	return receiverConfig, nil
+}
+
+// createRuntimeReceiver creates a receiver that is to discovered at runtime
+func (lo *runner) createRuntimeReceiver(cfg configmodels.Receiver) (component.MetricsReceiver, error) {
+	factory, err := factories.get(cfg.Type())
+	if err != nil {
+		return nil, err
+	}
+	receiverFactory := factory.(component.ReceiverFactoryOld)
+	return receiverFactory.CreateMetricsReceiver(lo.logger, cfg, lo.consumer)
+}
+
+// StartReceiver starts the given staticSubConfig merged with config values
+// that may have been discovered at runtime.
+func (lo *runner) StartReceiver(staticSubConfig *subreceiverConfig, subConfigFromEnv map[string]interface{}) (component.Receiver, error) {
+	lo.Lock()
+	defer lo.Unlock()
+
+	runtimeCfg, err := lo.loadRuntimeReceiverConfig(staticSubConfig, subConfigFromEnv)
+	if err != nil {
+		lo.logger.Error("failed loading runtime receiver", zap.String("receiverType", staticSubConfig.receiverType), zap.Error(err))
+	}
+	rcvr, err := lo.createRuntimeReceiver(runtimeCfg)
+	if err != nil {
+		lo.logger.Error("failed creating runtime receiver", zap.String("receiverType", staticSubConfig.receiverType), zap.Error(err))
+	}
+	if err := rcvr.Start(lo.host); err != nil {
+		return nil, err
+	}
+
+	lo.receivers[rcvr] = struct{}{}
+	return rcvr, nil
+}
+
+// StopReceiver stops the given receiver.
+func (lo *runner) StopReceiver(rcvr component.Receiver) error {
+	lo.Lock()
+	defer lo.Unlock()
+	delete(lo.receivers, rcvr)
+	return rcvr.Shutdown()
+}

--- a/receiver/receivercreator/runner_test.go
+++ b/receiver/receivercreator/runner_test.go
@@ -1,0 +1,84 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivercreator
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func exampleReceiverCreator(t *testing.T, name string) *receiverCreator {
+	cfg := exampleCreatorFactory(t)
+	rcCfg := cfg.Receivers[name]
+	factory := &Factory{}
+	rc, err := factory.CreateMetricsReceiver(zap.NewNop(), rcCfg, &mockMetricsConsumer{})
+	require.NoError(t, err)
+	return rc.(*receiverCreator)
+}
+
+func Test_loadAndCreateRuntimeReceiver(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	subConfig := rc.cfg.subreceiverConfigs["examplereceiver/1"]
+	require.NotNil(t, subConfig)
+	loader := rc.newLoader(component.NewMockHost())
+	loadedConfig, err := loader.loadRuntimeReceiverConfig(subConfig, map[string]interface{}{
+		"endpoint": "localhost:12345",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, loadedConfig)
+	exampleConfig := loadedConfig.(*config.ExampleReceiver)
+	// Verify that the overridden endpoint is used instead of the one in the config file.
+	assert.Equal(t, "localhost:12345", exampleConfig.Endpoint)
+	assert.Equal(t, "receiver_creator/1/examplereceiver/1{endpoint=\"localhost:12345\"}", exampleConfig.Name())
+
+	// Test that metric receiver can be created from loaded config.
+	t.Run("test create receiver from loaded config", func(t *testing.T) {
+		recvr, err := loader.createRuntimeReceiver(loadedConfig)
+		require.NoError(t, err)
+		assert.NotNil(t, recvr)
+		exampleReceiver := recvr.(*config.ExampleReceiverProducer)
+		assert.Equal(t, rc.nextConsumer, exampleReceiver.MetricsConsumer)
+	})
+}
+
+func TestStartStopReceiver(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	loader := rc.newLoader(component.NewMockHost())
+	rcvr, err := loader.StartReceiver(rc.cfg.subreceiverConfigs["examplereceiver/1"], map[string]interface{}{})
+	require.NotNil(t, rcvr)
+	require.NoError(t, err)
+
+	require.Len(t, loader.receivers, 1)
+
+	t.Run("test stop receiver", func(t *testing.T) {
+		assert.NoError(t, loader.StopReceiver(rcvr))
+	})
+}
+
+func TestShutdownReceivers(t *testing.T) {
+	rc := exampleReceiverCreator(t, "receiver_creator/1")
+	loader := rc.newLoader(component.NewMockHost())
+	_, err := loader.StartReceiver(rc.cfg.subreceiverConfigs["examplereceiver/1"], map[string]interface{}{})
+	require.NoError(t, err)
+
+	require.Len(t, loader.receivers, 1)
+	assert.NoError(t, loader.Shutdown())
+	assert.Nil(t, loader.receivers)
+}

--- a/receiver/receivercreator/testdata/config.yaml
+++ b/receiver/receivercreator/testdata/config.yaml
@@ -5,6 +5,8 @@ receivers:
       rule: test rule
       config:
         endpoint: localhost:12345
+    examplereceiver/2:
+      rule: enabled
 
 processors:
   exampleprocessor:


### PR DESCRIPTION
This adds the observer extension and enables receiver_creator to use it. There's still a lot to do and it is quite messy but wanted to put out there to see if there was any early feedback.

High level things to note:

* Observer API in extension/observer/observer.go
  * Struggled figuring out what the right way to model different kinds of endpoints. Some endpoints (e.g. nodes or pods) don't have ports whereas other things (e.g. containers) have ports and we want to handle them somewhat generically. So for now an Endpoint is just a thing that has an ID so we can manage them generically but when consuming them the dynamic receiver has to check the actual type to figure out what to do with it as it may have a port available or it may not. 
* Refactoring of receiver_creator to make it a bit more manageable and testable:
  * runner implements an interface to handle loading/starting of subreceivers
